### PR TITLE
Fix broken URL

### DIFF
--- a/Assets/Devdog/SciFiDesign/README.txt
+++ b/Assets/Devdog/SciFiDesign/README.txt
@@ -1,2 +1,2 @@
-Step 1. Visit http://devdog.nl/product/sci-fi-design/ for documentation, or go to Tools/Inventory Pro/Documentation in the main menu.
+Step 1. Visit https://sci-fi-ui-design-docs.readthedocs.io/en/latest/ for documentation, or go to Tools/Inventory Pro/Documentation in the main menu.
 Step 2. All demo scenes can be found in the Demos/ folder.


### PR DESCRIPTION
devdog.nl is no longer. Point directly to the docs on readthedocs.io